### PR TITLE
Remove libbsd dependency; update ssl; quote prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS=-g -Wall -I/usr/include/libxml2 -DLINUX -D_GNU_SOURCE=1
-LDFLAGS=-lcrypto -lcurl -lssl -lxml2 -lbsd
+LDFLAGS=-lcrypto -lcurl -lssl -lxml2
 
 OBJS=s3test.o s3string.o s3digest.o s3ops.o s3xml.o s3bucket.o
 

--- a/s3.h
+++ b/s3.h
@@ -25,13 +25,13 @@
 #ifndef _S3_H
 #define _S3_H
 
-#ifdef LINUX
-#include <bsd/string.h>
-#endif
-
 #include <string.h>
 #include <sys/queue.h>
 #include "s3xml.h"
+
+#ifdef LINUX
+size_t strlcpy(char *dst, const char *src, size_t size);
+#endif
 
 #define S3_SECRET_LENGTH 128
 #define S3_ID_LENGTH 128

--- a/s3bucket.c
+++ b/s3bucket.c
@@ -25,11 +25,6 @@
 #include "s3.h"
 #include "s3internal.h"
 
-#ifdef LINUX
-#include <bsd/string.h>
-#endif
-#include <string.h>
-
 void 
 s3_bucket_entry_free(struct s3_bucket_entry *entry) {
 	if (entry->key)
@@ -182,7 +177,7 @@ s3_list_bucket(struct S3 *s3, const char *bucket, const char *prefix) {
 	date = s3_make_date();
 
 	asprintf(&sign_data, "%s\n\n\n%s\n/%s/", method, date, bucket);	
-      	asprintf(&url, "http://%s.%s/?delimiter=/%s%s", bucket, s3->base_url, prefix ? "&prefix=" : "", prefix ? prefix : "");
+	asprintf(&url, "http://%s.%s/?delimiter=\"/\"%s\"%s\"", bucket, s3->base_url, prefix ? "&prefix=" : "", prefix ? prefix : "");
 
 	s3_perform_op(s3, method, url, sign_data, date, str, NULL, NULL, NULL);
 

--- a/s3digest.c
+++ b/s3digest.c
@@ -34,7 +34,7 @@ s3_hmac_sign(const char *key, const char *str, size_t len) {
 	unsigned char *digest; 
 	char *buf;
 	unsigned int digest_len = EVP_MAX_MD_SIZE; /* HMAC_Final needs at most EVP_MAX_MD_SIZE bytes */
-	HMAC_CTX ctx;
+	HMAC_CTX *ctx;
 	BIO *bmem, *b64;
 	BUF_MEM *bufptr;
 	
@@ -42,8 +42,8 @@ s3_hmac_sign(const char *key, const char *str, size_t len) {
 	ENGINE_register_all_complete();
 
 	/* Setup HMAC context, init with sha1 and our key*/ 
-	HMAC_CTX_init(&ctx);
-	HMAC_Init_ex(&ctx, key, strlen((char *)key), EVP_sha1(), NULL);
+	ctx = HMAC_CTX_new();
+	HMAC_Init_ex(ctx, key, strlen((char *)key), EVP_sha1(), NULL);
 
 	/* Create Base64 BIO filter that outputs to memory */
 	b64  = BIO_new(BIO_f_base64());
@@ -54,10 +54,10 @@ s3_hmac_sign(const char *key, const char *str, size_t len) {
 	digest = malloc(digest_len);
 
 	/* Push data into HMAC */
-	HMAC_Update(&ctx, (unsigned char *)str, (unsigned int)len);
+	HMAC_Update(ctx, (unsigned char *)str, (unsigned int)len);
 
 	/* Flush HMAC data into buffer */
-	HMAC_Final(&ctx, digest, &digest_len);
+	HMAC_Final(ctx, digest, &digest_len);
 
 	/* Write data into BIO, flush and fetch the data */
 	BIO_write(b64, digest, digest_len);
@@ -69,7 +69,7 @@ s3_hmac_sign(const char *key, const char *str, size_t len) {
 	buf[bufptr->length - 1] = '\0';
 
 	BIO_free_all(b64);
-	HMAC_CTX_cleanup(&ctx);
+	HMAC_CTX_free(ctx);
 
 	ENGINE_cleanup();
 	free(digest);

--- a/s3string.c
+++ b/s3string.c
@@ -28,6 +28,18 @@
 #include "s3.h"
 #include "s3internal.h"
 
+#ifdef LINUX
+size_t strlcpy(char *dst, const char *src, size_t size) {
+	size_t i;
+	for (i = 0; (i < (size - 1)) && (src[i] != 0); ++i) {
+		dst[i] = src[i];
+	}
+	dst[i] = 0;
+
+	return i;
+}
+#endif
+
 size_t
 s3_string_curl_writefunc(void *ptr, size_t len, size_t nmemb, struct s3_string *s) {
 	size_t new_len = s->len + len  *nmemb;


### PR DESCRIPTION
This makes a number of small changes:

1. Adds a simple strlcpy implementation on linux to avoid having to pull
in libbsd as a dependency.
2. Updates the HMAC code to make it compatible with OpenSSL 1.1.0 and
higher.
3. Quotes the s3 prefix sent in the URL when requesting bucket contents.
Without this the root prefix was listed every time.